### PR TITLE
优化从leveldb中删除整个hash、set、zset的逻辑

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -285,13 +285,16 @@ void delCommand(redisClient *c) {
         if (o != NULL) {
           switch(o->type) {
             case REDIS_SET: 
-              leveldbSclear(c->db->id,&server.ldb, c->argv[j]);
+              //leveldbSclear(c->db->id,&server.ldb, c->argv[j]);
+              leveldbDelSet(c->db->id, &server.ldb, c->argv[j], o);
               break;
             case REDIS_ZSET: 
-              leveldbZclear(c->db->id,&server.ldb, c->argv[j]);
+              //leveldbZclear(c->db->id,&server.ldb, c->argv[j]);
+              leveldbDelZset(c->db->id, &server.ldb, c->argv[j], o);
               break;
             case REDIS_HASH: 
-              leveldbHclear(c->db->id,&server.ldb, c->argv[j]);
+              //leveldbHclear(c->db->id,&server.ldb, c->argv[j]);
+              leveldbDelHash(c->db->id, &server.ldb, c->argv[j], o);
               break;
           }
         }

--- a/src/redis.h
+++ b/src/redis.h
@@ -1479,6 +1479,9 @@ void leveldbZremByObject(int dbid, struct leveldb *ldb, robj *arg, robj *field);
 void leveldbZclear(int dbid, struct leveldb *ldb, robj* argv);
 void leveldbFlushdb(int dbid, struct leveldb* ldb);
 void leveldbFlushall(struct leveldb* ldb);
+void leveldbDelHash(int dbid, struct leveldb *ldb, robj* objkey, robj *objval);
+void leveldbDelSet(int dbid, struct leveldb *ldb, robj* objkey, robj *objval);
+void leveldbDelZset(int dbid, struct leveldb *ldb, robj* objkey, robj *objval);
 
 #if defined(__GNUC__)
 void *calloc(size_t count, size_t size) __attribute__ ((deprecated));


### PR DESCRIPTION
优化从leveldb中删除整个hash、set、zset的逻辑，将从leveldb中遍历删除改为从内存中遍历删除。